### PR TITLE
Add Snaplert to Web/Ports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Flask_Session_Decryptor: Flask session注入解密
 
 - Wayback Machine: https://web.archive.org/ 历史网页存档
 - VisualPing: https://visualping.io/ 网站变更监控
+- Snaplert: https://snaplert.com 网站变更监控（可视化像素差异、AI摘要、元素选择器）
 - Dark Web Exposure: https://www.immuniweb.com/darkweb/
 - SG TCP/IP: https://www.speedguide.net/ports.php 端口数据库
 


### PR DESCRIPTION
添加 Snaplert（https://snaplert.com）到网页/端口监控部分。

Snaplert 是一款网站变更监控工具，支持：
- 可视化像素级差异对比（截图前后对比）
- AI 摘要（Claude）解释页面变更内容
- 元素级别选择器，精准监控页面特定区域
- 5分钟检测间隔
- 目前免费开放公测

适合用于竞争对手监控、合规页面追踪和OSINT侦察场景。

---

Adds [Snaplert](https://snaplert.com) to the Web/Ports section alongside VisualPing.

Snaplert monitors webpage changes with visual pixel diffs, AI-powered summaries, and an element-level zone picker. Currently free during open beta. Useful for tracking competitor pages, policy changes, and web reconnaissance.